### PR TITLE
Parrots should stay on your shoulder better

### DIFF
--- a/paper.yml
+++ b/paper.yml
@@ -94,7 +94,7 @@ world-settings:
     portal-search-vanilla-dimension-scaling: true
     only-players-collide: false
     allow-vehicle-collisions: true
-    parrots-are-unaffected-by-player-movement: false
+    parrots-are-unaffected-by-player-movement: true
     disable-explosion-knockback: false
     fix-climbing-bypassing-cramming-rule: false
     container-update-tick-rate: 1


### PR DESCRIPTION
This is more of an example setting change than an actual change request.
The setting that this would change is the `parrots-are-unaffected-by-player-movement` setting.
- This suggests setting it to true.
- True means that parrots to not leave a players shoulder when jumping or falling.
- If True, the only way to remove a parrot from your shoulder (besides dying) is to crouch.